### PR TITLE
Improved: code to use the variant metafields to enable backorder or preorder on the PDP page(#1yzbkyp)

### DIFF
--- a/changelogs/unreleased/-1yzbkyp.yml
+++ b/changelogs/unreleased/-1yzbkyp.yml
@@ -1,0 +1,7 @@
+---
+title: 'Improved: code to use the variant metafields to enable backorder or preorder
+  on the PDP page'
+ticket_id: "#1yzbkyp"
+merge_request: 22
+author: Yash Maheshwari
+type: added

--- a/scripts/script-tag.js
+++ b/scripts/script-tag.js
@@ -10,7 +10,7 @@
 
     // TODO Generate instance specific code URL in FTL. Used with <#noparse> after this code so that `` code is escaped
     // let baseUrl = '<@ofbizUrl secure="true"></@ofbizUrl>';
-    let shopUrl = ''
+    let shopUrl = window.origin;
 
     function getAddToCartLabel () {
         if (location.pathname.includes('products')) {

--- a/scripts/script-tag.js
+++ b/scripts/script-tag.js
@@ -2,6 +2,7 @@
     let jQueryPreOrder;
     let addToCartLabel;
     let localDeliveryDate, buttonLabel;
+    let productType;
 
     this.preOrderCustomConfig = {
         'enableCartRedirection': true
@@ -69,7 +70,8 @@
                 },
                 success: function (data) {
                     // TODO: check if tags is always a string or an array
-                    if (data.product.tags.includes('preorder')) {
+                    productType = data.product.tags.includes('Pre-Order') ? 'Pre-Order' : data.product.tags.includes('Back-Order') ? 'Back-Order' : ''
+                    if (data.product.tags.includes('Pre-Order') || data.product.tags.includes('Back-Order')) {
                         if (data.product.variants.find((variant) => variant.id == variantId).inventory_policy === 'continue')
                             resolve(true)
                         else
@@ -108,18 +110,18 @@
       
         if (location.pathname.includes('products')) {
             const cartForm = jQueryPreOrder("form[action='/cart/add']");
-            const id = cartForm.serializeArray().find(ele => ele.name === "id").value;
+            const variantId = cartForm.serializeArray().find(ele => ele.name === "id").value;
             // getting virtual product id
             const virtualId = meta.product.id;
             const preorderButton = jQueryPreOrder("#hc_preorderButton, .hc_preorderButton");
 
-            const checkItemAvailablity = await isItemAvailableForOrder(virtualId, id).catch(err => console.log(err));
+            const checkItemAvailablity = await isItemAvailableForOrder(virtualId, variantId).catch(err => console.log(err));
 
             if (!checkItemAvailablity) return ;
 
-            const metafields = await getVariantMetafields(virtualId, id).catch(err => console.error(err));
+            const metafields = await getVariantMetafields(virtualId, variantId).catch(err => console.error(err));
 
-            const metafield = metafields.find((metafield) => metafield.namespace === 'PRE_ORDER_DATE' || metafield.namespace === 'BACKORDER_DATE')
+            const metafield = metafields.find((metafield) => productType === 'Pre-Order' ? metafield.namespace === 'PRE_ORDER_DATE' : metafield.namespace === 'BACKORDER_DATE')
 
             let hcpreorderShipsFrom = jQueryPreOrder("#hc_preordershipsfrom");
             let span = jQueryPreOrder("#hc_preordershipsfrom span");


### PR DESCRIPTION
- Removed the checkPreorderItemAvailability API
- Used metafields.json to get the metafields of the current variant
- Enable preorder and backorder on the basis of metafields information